### PR TITLE
Add `db` folder permissions error (issue #18) workaround using `mkdir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the following resources to help you find the Active Record query methods tha
 
 ### Migration
 
-* Run `mkdir db` and then `mkdir db/migrate` to create the `migrate` folder within `db`, and then create file in the `db/migrate` folder called `001_create_shows.rb`. In this file, write the migration code to create a `shows` table. The table should have `name`, `network`, `day`, and `rating` columns. `name`, `network`, and `day` have a datatype of string, and `rating` has a datatype of integer.
+* Run `mkdir db` and then `mkdir db/migrate` to create the `migrate` folder within `db`. Then create a file in the `db/migrate` folder called `001_create_shows.rb`. In this file, write the migration code to create a `shows` table. The table should have `name`, `network`, `day`, and `rating` columns. `name`, `network`, and `day` have a datatype of string, and `rating` has a datatype of integer.
 * Create an `app` folder with a `models` folder within it, and then create a file, `show.rb`, in `app/models`. In this file, you will define a `Show` class that inherits from `ActiveRecord::Base`.
 * Now we need to create a second migration to add another column to our `shows` table. In the `db/migrate` folder, create another file, `002_add_season_to_shows.rb`, and write a migration to add a column, `season`, to the `shows` table. The datatype of this column is string.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use the following resources to help you find the Active Record query methods tha
 
 ### Migration
 
-* Create a `db` folder with a `migrate` folder within it, and then a file in the `db/migrate` folder called `001_create_shows.rb`. In this file, write the migration code to create a `shows` table. The table should have `name`, `network`, `day`, and `rating` columns. `name`, `network`, and `day` have a datatype of string, and `rating` has a datatype of integer.
+* Run `mkdir db` and then `mkdir db/migrate` to create the `migrate` folder within `db`, and then create file in the `db/migrate` folder called `001_create_shows.rb`. In this file, write the migration code to create a `shows` table. The table should have `name`, `network`, `day`, and `rating` columns. `name`, `network`, and `day` have a datatype of string, and `rating` has a datatype of integer.
 * Create an `app` folder with a `models` folder within it, and then create a file, `show.rb`, in `app/models`. In this file, you will define a `Show` class that inherits from `ActiveRecord::Base`.
 * Now we need to create a second migration to add another column to our `shows` table. In the `db/migrate` folder, create another file, `002_add_season_to_shows.rb`, and write a migration to add a column, `season`, to the `shows` table. The datatype of this column is string.
 


### PR DESCRIPTION
When an IDE user creates a folder via the tree, it's created with the permissions of their local user, and then transferred to the IDE server.  That's usually fine, but for this lab, creating a database file in a folder with `root` permissions violates some policy or other and makes trouble.

These mechanics are bypassed when creating folders with `mkdir`.  This PR changes the README to make the instructions explicitly use `mkdir` to create the folders.

CC: @aturkewi 