### PR TITLE
update method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Use the following resources to help you find the Active Record query methods tha
 
 You'll be defining the following methods:
 
-* `#highest_rating`: this method should return the highest value in the ratings column. *hint*: if there is a `#minimum` Active Record method, might there be a `#maximum` method?
-* `#most_popular_show`: this method should return the show with the highest rating. *hint*: use the `#highest_rating` method as a helper method.
-* `#lowest_rating`: returns the lowest value in the ratings column.
-* `#least_popular_show`: returns the show with the lowest rating.
-* `#ratings_sum`: returns the sum of all of the ratings.
-* `#popular_shows`: returns an array of all of the shows that have a rating greater than `5`. *hint*: use the `#where` Active Record method.
-* `#shows_by_alphabetical_order`: returns an array of all of the shows sorted by alphabetical order according to their names. *hint*: use the `#order` Active Record method.
+* `::highest_rating`: this method should return the highest value in the ratings column. *hint*: if there is a `#minimum` Active Record method, might there be a `#maximum` method?
+* `::most_popular_show`: this method should return the show with the highest rating. *hint*: use the `#highest_rating` method as a helper method.
+* `::lowest_rating`: returns the lowest value in the ratings column.
+* `::least_popular_show`: returns the show with the lowest rating.
+* `::ratings_sum`: returns the sum of all of the ratings.
+* `::popular_shows`: returns an array of all of the shows that have a rating greater than `5`. *hint*: use the `#where` Active Record method.
+* `::shows_by_alphabetical_order`: returns an array of all of the shows sorted by alphabetical order according to their names. *hint*: use the `#order` Active Record method.
 
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/activerecord-tvshow' title='Objectives'>Objectives</a> on Learn.co and start learning to code for free.</p>
 


### PR DESCRIPTION
Use ruby-doc naming convention for class method names. Previous naming convention suggested that the methods needed to be instance methods. 