### PR TITLE
Changed Active Record & Rake Gem Versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gem 'pry'
 gem "rspec"
-gem "activerecord"
+gem "activerecord", "4.2.1"
 gem "sqlite3"
-gem "rake"
+gem "rake", "10.4.2"
 gem "database_cleaner"


### PR DESCRIPTION
Set both Active Record and Rake gems to have a strict versioning. Doing this allows students to omit `bundle exec`. With out the strict versioning, students are forced to append `bundle exec` to their rake commands.